### PR TITLE
reduce loglevel in prod because its not allowed to log the HBCI message

### DIFF
--- a/multibanking-server/src/main/resources/application.yml
+++ b/multibanking-server/src/main/resources/application.yml
@@ -158,7 +158,10 @@ spring:
   autoconfigure.exclude:
     - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
     - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-
+    -
+logging:
+  level:
+    org.kapott.hbci.comm.CommPinTan: INFO
 ---
 
 spring:

--- a/multibanking-server/src/main/resources/application.yml
+++ b/multibanking-server/src/main/resources/application.yml
@@ -158,7 +158,7 @@ spring:
   autoconfigure.exclude:
     - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
     - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-    -
+
 logging:
   level:
     org.kapott.hbci.comm.CommPinTan: INFO


### PR DESCRIPTION
We encountered the problem, that the full HBCI message would be logged in production. Which is a security issue.