### PR TITLE
BGT-152 extend transfer object to support oauth token

### DIFF
--- a/multibanking-server/src/main/java/de/adorsys/multibanking/web/model/TransactionAuthorisationRequestTO.java
+++ b/multibanking-server/src/main/java/de/adorsys/multibanking/web/model/TransactionAuthorisationRequestTO.java
@@ -11,4 +11,9 @@ public class TransactionAuthorisationRequestTO {
         required = true)
     @ToString.Exclude
     private String scaAuthenticationData;
+
+    @ApiModelProperty(value = "The OAuth Token for the process if the SCA method supports it. Otherwise empty.",
+        required = true)
+    @ToString.Exclude
+    private String oauthToken;
 }


### PR DESCRIPTION
Preparation for OAuth support:
I need the extend in the TO to enable the transport of the token through the system.
The usage will be done later. (It should be some kind of header value later)
I have created a separate value because the usage will be different from the TAN value.
Even though theoretically it could be used together with a TAN value as well.